### PR TITLE
refactor: moved the LottieDrawable outside the paging adapter

### DIFF
--- a/app/src/main/java/com/example/suki/movie/filter/ui/adapter/paging/MovieFilterPagingDataAdapter.kt
+++ b/app/src/main/java/com/example/suki/movie/filter/ui/adapter/paging/MovieFilterPagingDataAdapter.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.airbnb.lottie.LottieCompositionFactory
 import com.airbnb.lottie.LottieDrawable
 import com.bumptech.glide.Glide
 import com.example.suki.R
@@ -16,7 +15,8 @@ import com.example.suki.movie.filter.ui.adapter.MovieFilterGenreRecyclerViewAdap
 import timber.log.Timber
 
 class MovieFilterPagingDataAdapter(
-    private val listener: OnItemClickListener
+    private val listener: OnItemClickListener,
+    private val lottieDrawable: LottieDrawable
 ) : PagingDataAdapter<MovieFilterModel, MovieFilterPagingDataAdapter.MovieFilterViewHolder>(
     MovieFilterDiffUtil()
 ) {
@@ -66,13 +66,6 @@ class MovieFilterPagingDataAdapter(
                         Timber.d("genre: $genre")
                     }
                 })
-            val lottieDrawable = LottieDrawable()
-            LottieCompositionFactory.fromRawRes(itemView.context, R.raw.image_loader)
-                .addListener { lottieComposition ->
-                    lottieDrawable.composition = lottieComposition
-                    lottieDrawable.repeatCount = LottieDrawable.INFINITE
-                    lottieDrawable.playAnimation()
-                }
 
             binding.apply {
                 Glide

--- a/app/src/main/java/com/example/suki/movie/filter/ui/fragment/MovieFilterFragment.kt
+++ b/app/src/main/java/com/example/suki/movie/filter/ui/fragment/MovieFilterFragment.kt
@@ -11,6 +11,8 @@ import androidx.fragment.app.viewModels
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.airbnb.lottie.LottieCompositionFactory
+import com.airbnb.lottie.LottieDrawable
 import com.example.suki.R
 import com.example.suki.common.util.Constant.STATUS_WATCHING
 import com.example.suki.databinding.FragmentMovieFilterBinding
@@ -87,8 +89,17 @@ class MovieFilterFragment : Fragment(), MovieFilterPagingDataAdapter.OnItemClick
     }
 
     private fun setPagingRecyclerView() {
+        val lottieDrawable = LottieDrawable()
+        LottieCompositionFactory.fromRawRes(requireContext(), R.raw.image_loader)
+            .addListener { lottieComposition ->
+                lottieDrawable.composition = lottieComposition
+                lottieDrawable.repeatCount = LottieDrawable.INFINITE
+                lottieDrawable.playAnimation()
+            }
+
         movieFilterPagingDataAdapter = MovieFilterPagingDataAdapter(
-            this
+            this,
+            lottieDrawable
         )
         val pagingHeaderAdapter =
             MovieFilterLoadStateAdapter { movieFilterPagingDataAdapter.retry() }


### PR DESCRIPTION
The LottieDrawable object, since being inside the PagingAdapter gets instantiated for each item, leading to the memory issues, have moved it and instantiated it in the fragment instead and is now being passed to the adapter. 